### PR TITLE
Replace `setsid -f …` by `setsid … &`

### DIFF
--- a/notice.sh
+++ b/notice.sh
@@ -161,7 +161,7 @@ kill_current_daemon () {
 }
 
 run () {
-	(($#)) && eval setsid -f $@ >&- 2>&- <&-
+	(($#)) && { eval setsid $@ >&- 2>&- <&- & }
 	${FORCE_CLOSE} && "$0" -i ${ID} -c
 }
 
@@ -313,7 +313,7 @@ x="${x%,*}" ID="${x#* }"
 
 # background task to monitor dbus and perform the actions
 x= ;${FORCE_CLOSE} && x='-f'
-((${#ACMDS[@]})) && setsid -f "$0" -i ${ID} $x -% "${ACMDS[@]}" >&- 2>&- <&-
+((${#ACMDS[@]})) && { setsid "$0" -i ${ID} $x -% "${ACMDS[@]}" >&- 2>&- <&- & }
 
 # background task to wait TTL seconds and then actively close the notification
-${FORCE_CLOSE} && ((TTL>0)) && setsid -f "$0" -t ${TTL} -i ${ID} -c >&- 2>&- <&-
+${FORCE_CLOSE} && ((TTL>0)) && { setsid "$0" -t ${TTL} -i ${ID} -c >&- 2>&- <&- & }


### PR DESCRIPTION
`setsid -f` is a rather "new" (for util-linux - it's 6+ years old…) feature introduced with util-linux v2.32. Since README.md claims that only Bash is required, we musn't use anything that isn't part of either Bash, or a POSIX utility - and e.g. Busybox's `setsid` doesn't support `setsid -f` either. Thus we replace `setsid -f …` by `setsid … &`.

---

Off Topic: Great fork, thank you! :heart: Besides some small issues (also see #2 and #3) your fork is the only I found that works with more complex actions, too :+1: I was about to create yet another `notify-send` drop-in replacement with Python just because I couldn't find any working script... Luckily I found yours.

Why did you disable GitHub's issue tracker? It would be great if we had a place to track suggestions and report issues.