### PR TITLE
Exit with rc=0 on success

### DIFF
--- a/notice.sh
+++ b/notice.sh
@@ -156,7 +156,7 @@ kill_current_daemon () {
 	local d x ;local -i i p
 	read d i p x < $1
 	rm -f $1
-	((p>1)) || exit
+	((p>1)) || exit 0
 	kill $p
 }
 
@@ -189,7 +189,7 @@ action_daemon () {
 		esac
 		break
 	done
-	exit
+	exit 0
 }
 
 #
@@ -201,7 +201,7 @@ close_notification () {
 	((TTL>0)) && sleep ${TTL}
 	gdbus call ${GDBUS_ARGS[@]} --method org.freedesktop.Notifications.CloseNotification -- ${ID} >&-
 	[[ ${ID_FILE} ]] && rm -f "${ID_FILE}"
-	exit
+	exit 0
 }
 
 add_hint () {
@@ -317,3 +317,5 @@ x= ;${FORCE_CLOSE} && x='-f'
 
 # background task to wait TTL seconds and then actively close the notification
 ${FORCE_CLOSE} && ((TTL>0)) && setsid -f "$0" -t ${TTL} -i ${ID} -c >&- 2>&- <&-
+
+exit 0


### PR DESCRIPTION
Checks like `${FORCE_CLOSE} && ((TTL>0)) && …` yield `false` when the option wasn't set, and therefore set `$?` to a non-zero exit code. Not providing an exit code with `exit` (or not calling `exit` at the end of the script) causes Bash to exit with `$?`, which therefore might yield a non-zero exit code even though everything went fine. Let's be more explicit here and do `exit 0` instead.

---

Please note that this will likely cause a merge conflict with #1, but a really minor one... :wink:

As already noted in #1 it would be great if we could enable GitHub's issue tracker. This would enable me to create an issue to track the effort in refactoring the code to allow `set -e -u -o pipefail`. For example, instead of `${FORCE_CLOSE} && ((TTL>0)) && …`, one could also do `! ${FORCE_CLOSE} || ((TTL=0) || …`, i.e. invert the conditions, so that they default to `true`. Even if nobody ever finds the time to actually refactor the code that way, we should at least track the suggestion. What do you think?