### PR TITLE
Clarify that `notice.sh` will always return the notification's ID

### DIFF
--- a/notice.sh
+++ b/notice.sh
@@ -102,7 +102,7 @@ Options:
 
   -i, --id=ID                       ID of an existing notification to update or close
   -i, --id=@FILENAME                write ID to & read ID from FILENAME
-                                    If --id is not used, then ID is printed to stdout.
+                                    If --id is not set to a FILENAME, a new ID is printed to stdout.
 
   -t, --ttl=SECONDS                 Time-To-Live, in seconds, before the notification closes itself
                                     0 = forever


### PR DESCRIPTION
To be honest, I'm not entirely sure why `notice.sh` (or better: `gdbus`) returns a new notification ID even when updating an existing notification, and I'm even less sure why we can use either the original or any later notification ID to update a notification, but in the end it probably doesn't really matter... Just tell the user that `notice.sh` will always print a notification ID even when updating an existing notification (other `notify-send` implementations usually don't print a new notification ID when updating notifications).